### PR TITLE
Dev andrew

### DIFF
--- a/R/ojo_fee_filter.R
+++ b/R/ojo_fee_filter.R
@@ -32,7 +32,7 @@ ojo_fee_filter <- function(df) {
                          "TR")
 
   filter_string_desc <- paste(filter_desc_terms, collapse = "|")
-  filter_string_codes <- paste(filter_code_terms, collapse = "|")
+  filter_string_codes <- paste("\\b", filter_code_terms, "\\b", sep = "", collapse = "|")
 
   fdf <- df %>%
     filter(!str_detect(min_desc, filter_string_desc),

--- a/R/ojo_fee_filter.R
+++ b/R/ojo_fee_filter.R
@@ -16,19 +16,19 @@
 ojo_fee_filter <- function(df) {
 
   filter_desc_terms <- c("CASH BOND",
-                    "FORFEIT",
-                    "WARR(E|A)NT RETUR",
-                    "JAIL COSTS",
-                    "CREDIT TIME SERVED",
-                    "PAID BY DIS",
-                    "DECEASED",
-                    "ADJUSTING ENTRY",
-                    "CASE NOT PROCESSED")
-  
-  filter_code_terms <- c("AC22", 
-                         "AC35", 
-                         "AC72", 
-                         "SFIJC", 
+                         "FORFEIT",
+                         "WARR(E|A)NT RETUR",
+                         "JAIL COSTS",
+                         "CREDIT TIME SERVED",
+                         "PAID BY DIS",
+                         "DECEASED",
+                         "ADJUSTING ENTRY",
+                         "CASE NOT PROCESSED")
+
+  filter_code_terms <- c("AC22",
+                         "AC35",
+                         "AC72",
+                         "SFIJC",
                          "TR")
 
   filter_string_desc <- paste(filter_desc_terms, collapse = "|")
@@ -41,11 +41,10 @@ ojo_fee_filter <- function(df) {
            fee_amt > 0)
 
   filtered_results <- df %>%
-    mutate(exclusion = if_else(fee_amt > 300000, "AMOUNT TOO HIGH (> $300,000)",
-                               ifelse(fee_amt < 0, "AMOUNT TOO LOW (< $0)",
-                                      ifelse(str_detect(min_desc, filter_string_desc), str_extract(min_desc, filter_string_desc),
-                                             ifelse(str_detect(min_code, filter_string_codes), min_code, NA))))) %>%
-                                 
+    mutate(exclusion = case_when(fee_amt > 300000 ~ "AMOUNT TOO HIGH (> $300,000)",
+                                 str_detect(min_desc, filter_string_desc) ~ str_extract(min_desc, filter_string_desc),
+                                 str_detect(min_code, filter_string_codes) ~ min_code,
+                                 TRUE ~ as.character(NA)))  %>%
     group_by(exclusion) %>%
     filter(!is.na(exclusion)) %>%
     summarize(rows_filtered = n(),

--- a/R/ojo_fee_filter.R
+++ b/R/ojo_fee_filter.R
@@ -3,7 +3,7 @@
 #' Filters a data frame of fees from the OJO database using consistent criteria. ojo_fee_filter removes rows that contain certain strings and those that are over $300,000. Requires columns named 'min_desc' and 'fee_amt'.
 #'
 #' Filter code:
-#' filter(!str_detect(min_desc, "CASH BOND|FORFEIT|WARR(E|A)NT RETUR|JAIL COSTS|CREDIT TIME SERVED|PAID BY DIS|DECEASED|ADJUSTING ENTRY|CASE NOT PROCESSED"), fee_amt < 300000)
+#' filter(!str_detect(min_desc, "CASH BOND|FORFEIT|WARR(E|A)NT RETUR|JAIL COSTS|CREDIT TIME SERVED|PAID BY DIS|DECEASED|ADJUSTING ENTRY|CASE NOT PROCESSED|AC22|AC36|AC72|SFIJC|TR"), fee_amt < 300000, fee_amt > 0)
 #'
 #' @examples
 #' \dontrun{
@@ -23,13 +23,19 @@ ojo_fee_filter <- function(df) {
                     "PAID BY DIS",
                     "DECEASED",
                     "ADJUSTING ENTRY",
-                    "CASE NOT PROCESSED")
+                    "CASE NOT PROCESSED",
+                    "AC22",               # Incarceration costs
+                    "AC35",               # Incarceration costs
+                    "AC72",               # Incarceration costs (split between Sheriff and DA in Pushmataha)
+                    "SFIJC",              # Incarceration costs
+                    "TR")                 # Account transfers
 
   filter_string <- paste(filter_terms, collapse = "|")
 
   fdf <- df %>%
     filter(!str_detect(min_desc, filter_string),
-           fee_amt < 300000)
+           fee_amt < 300000,
+           fee_amt > 0)
 
   filtered_results <- df %>%
     mutate(exclusion = if_else(fee_amt > 300000,


### PR DESCRIPTION
I updated ojo_fee_filter() to filter out some other fee codes / descriptions we aren't interested in. Specifically, I set it to filter:

- entries with fee code AC22 (alternative code for incarceration / jail costs)
- entries with fee code AC35 (another alternative code for incarceration / jail costs)
- entries with fee code  AC72 (another alternative code for incarceration / jail costs)
- entries with an amount less than zero 

I also (I think) made it a bit easier to add new filters, now there's a list of description keywords (e.g. "BOND", "JAIL", etc.) to filter and a list of codes (e.g. "AC22") to filter.