### PR TITLE
Remove urbnthemes dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,8 +17,7 @@ Imports:
     glue,
     sp,
     leaflet,
-    dbx,
-    urbnthemes
+    dbx
 Encoding: UTF-8
 LazyData: true
 RoxygenNote: 7.1.1


### PR DESCRIPTION
This dependency is not actually referenced anywhere in the code. We simply used their repository as guidelines for our own templates which don't depend on their source code.